### PR TITLE
Use default sort (alphabetical) function

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var qp = {
   toString: function (params) {
     var str = '';
     toPairs(params)
-      .sort(function(a, b) { return a[0] > b[0]; })
+      .sort()
       .map(function(param) {
           if (param[1] !== undefined) {
               if (str !== '') str += '&';


### PR DESCRIPTION
Sort functions shouldn't return a boolean, but positive, negative o zero numbers. This sort function was inconsistent between Chrome and iOS Safari because of that.

You can read more about this here:
https://stackoverflow.com/questions/24080785/sorting-in-javascript-shouldnt-returning-a-boolean-be-enough-for-a-comparison